### PR TITLE
The `core/domain` gradle module is created (#10)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,9 +60,6 @@ jobs:
     needs: build
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 60
-    strategy:
-      matrix:
-        api-level: [ 29 ] # You can add other APIs too.
 
     steps:
       - name: Checkout
@@ -83,7 +80,7 @@ jobs:
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${{ matrix.api-level }}
+          api-level: 29
           arch: x86_64
           disable-animations: true
           disk-size: 6000M

--- a/core/domain/build.gradle
+++ b/core/domain/build.gradle
@@ -4,3 +4,7 @@ apply from: "$rootDir/plugins/android-test.gradle"
 android {
   namespace "app.taskify.core.domain"
 }
+
+dependencies {
+  implementation(libs.coroutines.core)
+}

--- a/core/domain/build.gradle
+++ b/core/domain/build.gradle
@@ -1,0 +1,6 @@
+apply from: "$rootDir/plugins/kotlin-android.gradle"
+apply from: "$rootDir/plugins/android-test.gradle"
+
+android {
+  namespace "app.taskify.core.domain"
+}

--- a/core/domain/src/androidTest/java/app/taskify/core/domain/TextTest.kt
+++ b/core/domain/src/androidTest/java/app/taskify/core/domain/TextTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.domain
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@SmallTest
+@RunWith(AndroidJUnit4::class)
+class TextTest {
+
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  @Test
+  fun staticStringText_ReturnsGivenString() {
+    val expectedString = "String"
+    val text = Text(expectedString)
+    assertThat(text.getString(context)).isEqualTo(expectedString)
+  }
+
+  @Test
+  fun resourceString_ReturnsSpecifiedStringResource() {
+    val expectedString = context.resources.getString(R.string.test_string)
+    val text = Text(R.string.test_string)
+    assertThat(text.getString(context)).isEqualTo(expectedString)
+  }
+
+  @Test
+  fun resourceStringWithOneArg_ReturnsSpecifiedStringResourceWithGivenArgument() {
+    val expectedString = context.resources.getString(R.string.test_string_with_one_arg, 5)
+    val text = Text(R.string.test_string_with_one_arg, 5)
+    assertThat(text.getString(context)).isEqualTo(expectedString)
+  }
+
+  @Test
+  fun resourceStringWithTwoArgs_ReturnsSpecifiedStringResourceWithGivenArguments() {
+    val expectedString = context.resources.getString(R.string.test_string_with_two_arg, 5, 6)
+    val text = Text(R.string.test_string_with_two_arg, 5, 6)
+    assertThat(text.getString(context)).isEqualTo(expectedString)
+  }
+
+  @Test
+  fun testOverwrittenEqualsFunction() {
+    val text1 = Text("Test")
+    val text2 = Text("Test")
+    assertThat(text1).isEqualTo(text2)
+
+    val text3 = Text(R.string.test_string)
+    val text4 = Text(R.string.test_string)
+    assertThat(text3).isEqualTo(text4)
+
+    val text5 = Text(R.string.test_string_with_one_arg, 1)
+    val text6 = Text(R.string.test_string_with_one_arg, 1)
+    assertThat(text5).isEqualTo(text6)
+
+    val text7 = Text(R.string.test_string_with_two_arg, 1, 2)
+    val text8 = Text(R.string.test_string_with_two_arg, 1, 2)
+    assertThat(text7).isEqualTo(text8)
+  }
+
+  @Test
+  fun testOverwrittenHashcodeFunction() {
+    val text1 = Text("Test")
+    val text2 = Text("Test")
+    assertThat(text1.hashCode()).isEqualTo(text2.hashCode())
+
+    val text3 = Text(R.string.test_string)
+    val text4 = Text(R.string.test_string)
+    assertThat(text3.hashCode()).isEqualTo(text4.hashCode())
+
+    val text5 = Text(R.string.test_string_with_one_arg, 1)
+    val text6 = Text(R.string.test_string_with_one_arg, 1)
+    assertThat(text5.hashCode()).isEqualTo(text6.hashCode())
+
+    val text7 = Text(R.string.test_string_with_two_arg, 1, 2)
+    val text8 = Text(R.string.test_string_with_two_arg, 1, 2)
+    assertThat(text7.hashCode()).isEqualTo(text8.hashCode())
+  }
+}

--- a/core/domain/src/main/java/app/taskify/core/domain/Text.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/Text.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.domain
+
+import android.content.Context
+import java.io.Serializable
+
+class Text private constructor(
+  private val value: Any,
+) : Serializable {
+
+  constructor(value: String) : this(value as Any)
+  constructor(resId: Int, vararg args: Any) : this(Resource(resId, args))
+
+  @Suppress("SpreadOperator")
+  fun getString(context: Context): String = when (value) {
+    is Resource -> context.resources.getString(value.resId, *value.args)
+    else -> value as String
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+    if (other !is Text) return false
+    return value == other.value
+  }
+
+  override fun hashCode(): Int = value.hashCode()
+
+  override fun toString(): String = when (value) {
+    is Resource -> value.toString() // Resource(resId=$resId, args=${args.contentToString()})
+    else -> "Text(value=$value)"
+  }
+
+  private class Resource(
+    val resId: Int,
+    val args: Array<out Any>,
+  ) : Serializable {
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (javaClass != other?.javaClass) return false
+      if (other !is Resource) return false
+      if (resId != other.resId) return false
+      return args.contentEquals(other.args)
+    }
+
+    override fun hashCode(): Int = 31 * resId + args.contentHashCode()
+    override fun toString(): String = "Resource(resId=$resId, args=${args.contentToString()})"
+  }
+}

--- a/core/domain/src/main/java/app/taskify/core/domain/matcher/EmailMatcher.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/matcher/EmailMatcher.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.domain.matcher
+
+interface EmailMatcher {
+
+  fun matches(email: CharSequence): Boolean
+}

--- a/core/domain/src/main/java/app/taskify/core/domain/preferences/AuthPreferences.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/preferences/AuthPreferences.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.domain.preferences
+
+import kotlinx.coroutines.flow.Flow
+
+interface AuthPreferences {
+
+  val isAuthenticated: Flow<Boolean>
+
+  suspend fun setAuthenticated(isAuthenticated: Boolean)
+}

--- a/core/domain/src/main/java/app/taskify/core/domain/preferences/OnboardingPreferences.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/preferences/OnboardingPreferences.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.domain.preferences
+
+import kotlinx.coroutines.flow.Flow
+
+interface OnboardingPreferences {
+
+  val isOnboardingCompleted: Flow<Boolean>
+
+  suspend fun setOnboardingCompleted(isOnboardingCompleted: Boolean)
+}

--- a/core/domain/src/main/java/app/taskify/core/domain/util/Result.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/util/Result.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.domain.util
+
+import java.util.concurrent.CancellationException
+
+@Suppress("TooGenericExceptionCaught")
+inline fun <T> resultOf(block: () -> T): Result<T> = try {
+  Result.success(block())
+} catch (cancellationException: CancellationException) {
+  throw cancellationException
+} catch (throwable: Throwable) {
+  Result.failure(throwable)
+}

--- a/core/domain/src/main/res/values/test_strings.xml
+++ b/core/domain/src/main/res/values/test_strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and limitations under the License.
+  -->
+
+<resources>
+  <!-- Test string for testing Text wrapper class -->
+  <string name="test_string" translatable="false">Test</string>
+  <string name="test_string_with_one_arg" translatable="false">Test %1$s</string>
+  <string name="test_string_with_two_arg" translatable="false">Test %s %s</string>
+</resources>

--- a/core/test/build.gradle
+++ b/core/test/build.gradle
@@ -1,0 +1,13 @@
+apply from: "$rootDir/plugins/kotlin-android.gradle"
+apply from: "$rootDir/plugins/kotlin-test.gradle"
+
+android {
+  namespace "app.taskify.core.test"
+}
+
+dependencies {
+  implementation project(":core:domain")
+
+  implementation(libs.mockk)
+  implementation(libs.coroutines.core)
+}

--- a/core/test/src/main/java/app/taskify/core/test/matcher/FakeEmailMatcher.kt
+++ b/core/test/src/main/java/app/taskify/core/test/matcher/FakeEmailMatcher.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.test.matcher
+
+import app.taskify.core.domain.matcher.EmailMatcher
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@Suppress("unused")
+class FakeEmailMatcher {
+
+  val mock: EmailMatcher = mockk()
+
+  fun mockResultForEmail(
+    email: CharSequence,
+    result: Boolean,
+  ) {
+    every { mock.matches(email) } returns result
+  }
+
+  fun verifyEmailMatcherNeverCalled() {
+    verify(exactly = 0) { mock.matches(any()) }
+  }
+}

--- a/core/test/src/main/java/app/taskify/core/test/preferences/FakeAuthPreferences.kt
+++ b/core/test/src/main/java/app/taskify/core/test/preferences/FakeAuthPreferences.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.test.preferences
+
+import app.taskify.core.domain.preferences.AuthPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+
+@Suppress("unused")
+class FakeAuthPreferences {
+
+  val mock: AuthPreferences = mockk(relaxUnitFun = true)
+
+  fun mockAuthenticatedForResult(result: Boolean) {
+    every { mock.isAuthenticated } answers { flowOf(result) }
+  }
+
+  fun verifyIsAuthenticatedNeverCalled() {
+    verify(exactly = 0) { mock.isAuthenticated }
+  }
+}

--- a/core/test/src/main/java/app/taskify/core/test/preferences/FakeOnboardingPreferences.kt
+++ b/core/test/src/main/java/app/taskify/core/test/preferences/FakeOnboardingPreferences.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.test.preferences
+
+import app.taskify.core.domain.preferences.OnboardingPreferences
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+
+@Suppress("unused")
+class FakeOnboardingPreferences {
+
+  val mock: OnboardingPreferences = mockk(relaxUnitFun = true)
+
+  fun mockOnboardingCompletedForResult(result: Boolean) {
+    every { mock.isOnboardingCompleted } answers { flowOf(result) }
+  }
+
+  fun verifyIsOnboardingCompletedNeverCalled() {
+    verify(exactly = 0) { mock.isOnboardingCompleted }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ desugar = "2.0.3"
 core-ktx = "1.10.0"
 appcompat = "1.6.1"
 material = "1.8.0"
+coroutines = "1.6.4"
 
 [libraries]
 desugar = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar" }
@@ -20,6 +21,10 @@ material = { group = "com.google.android.material", name = "material", version.r
 javax-inject = { group = "javax.inject", name = "javax.inject", version = "1" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+
+coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+
 
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 mockk = { group = "io.mockk", name = "mockk-android", version = "1.13.5" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 gradle = "8.0.0"
 kotlin = "1.8.21"
 kotlinter = "3.14.0"
-detekt = "1.22.0"
+detekt = "1.23.0-RC2"
 versions = "0.46.0"
 hilt = "2.45"
 

--- a/plugins/config/detekt.yml
+++ b/plugins/config/detekt.yml
@@ -702,7 +702,7 @@ style:
   UntilInsteadOfRangeTo:
     active: false
   UnusedImports:
-    active: false
+    active: true
   #  UnusedParameter:
   #    active: true
   #    allowedNames: 'ignored|expected'

--- a/plugins/config/detekt.yml
+++ b/plugins/config/detekt.yml
@@ -190,6 +190,8 @@ coroutines:
     active: true
   SleepInsteadOfDelay:
     active: true
+  SuspendFunSwallowedCancellation:
+    active: false
   SuspendFunWithCoroutineScopeReceiver:
     active: false
   SuspendFunWithFlowReturnType:
@@ -401,8 +403,8 @@ potential-bugs:
     active: true
     forbiddenTypePatterns:
       - 'kotlin.String'
-  #  CastNullableToNonNullableType:
-  #    active: false
+  CastNullableToNonNullableType:
+    active: false
   CastToNullableType:
     active: false
   Deprecation:
@@ -422,7 +424,7 @@ potential-bugs:
       - 'java.util.HashMap'
   ElseCaseInsteadOfExhaustiveWhen:
     active: false
-  #    ignoredSubjectTypes: []
+    ignoredSubjectTypes: [ ]
   EqualsAlwaysReturnsTrueOrFalse:
     active: true
   EqualsWithHashCodeExist:
@@ -501,10 +503,14 @@ style:
   active: true
   AlsoCouldBeApply:
     active: false
-  #  BracesOnIfStatements:
-  #    active: false
-  #    singleLine: 'never'
-  #    multiLine: 'always'
+  BracesOnIfStatements:
+    active: false
+    singleLine: 'never'
+    multiLine: 'always'
+  BracesOnWhenStatements:
+    active: false
+    singleLine: 'necessary'
+    multiLine: 'consistent'
   CanBeNonNullable:
     active: false
   CascadingCallWrapping:
@@ -518,12 +524,22 @@ style:
     active: false
     conversionFunctionPrefix:
       - 'to'
-  #    allowOperators: false
+    allowOperators: false
   DataClassShouldBeImmutable:
     active: false
   DestructuringDeclarationWithTooManyEntries:
     active: true
     maxDestructuringEntries: 3
+  DoubleNegativeLambda:
+    active: false
+    negativeFunctions:
+      - reason: 'Use `takeIf` instead.'
+        value: 'takeUnless'
+      - reason: 'Use `all` instead.'
+        value: 'none'
+    negativeFunctionNameParts:
+      - 'not'
+      - 'non'
   EqualsNullCall:
     active: true
   EqualsOnSignatureLine:
@@ -535,28 +551,29 @@ style:
   ExpressionBodySyntax:
     active: false
     includeLineWrapping: false
-  #  ForbiddenAnnotation:
-  #    active: false
-  #    annotations:
-  #      - reason: 'it is a java annotation. Use `Suppress` instead.'
-  #        value: 'java.lang.SuppressWarnings'
-  #      - reason: 'it is a java annotation. Use `kotlin.Deprecated` instead.'
-  #        value: 'java.lang.Deprecated'
-  #      - reason: 'it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.'
-  #        value: 'java.lang.annotation.Documented'
-  #      - reason: 'it is a java annotation. Use `kotlin.annotation.Target` instead.'
-  #        value: 'java.lang.annotation.Target'
-  #      - reason: 'it is a java annotation. Use `kotlin.annotation.Retention` instead.'
-  #        value: 'java.lang.annotation.Retention'
-  #      - reason: 'it is a java annotation. Use `kotlin.annotation.Repeatable` instead.'
-  #        value: 'java.lang.annotation.Repeatable'
-  #      - reason: 'Kotlin does not support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265'
-  #        value: 'java.lang.annotation.Inherited'
+  ForbiddenAnnotation:
+    active: false
+    annotations:
+      - reason: 'it is a java annotation. Use `Suppress` instead.'
+        value: 'java.lang.SuppressWarnings'
+      - reason: 'it is a java annotation. Use `kotlin.Deprecated` instead.'
+        value: 'java.lang.Deprecated'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.'
+        value: 'java.lang.annotation.Documented'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Target` instead.'
+        value: 'java.lang.annotation.Target'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Retention` instead.'
+        value: 'java.lang.annotation.Retention'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Repeatable` instead.'
+        value: 'java.lang.annotation.Repeatable'
+      - reason: 'Kotlin does not support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265'
+        value: 'java.lang.annotation.Inherited'
   ForbiddenComment:
     active: true
     values:
       - 'FIXME:'
       - 'STOPSHIP:'
+      - 'TODO:'
     allowedPatterns: ''
     customMessage: ''
   ForbiddenImport:
@@ -664,10 +681,10 @@ style:
     active: false
   SpacingBetweenPackageAndImports:
     active: false
-  #  StringShouldBeRawString:
-  #    active: false
-  #    maxEscapedCharacterCount: 2
-  #    ignoredCharacters: []
+  StringShouldBeRawString:
+    active: false
+    maxEscapedCharacterCount: 2
+    ignoredCharacters: [ ]
   ThrowsCount:
     active: true
     max: 2
@@ -702,18 +719,18 @@ style:
   UntilInsteadOfRangeTo:
     active: false
   UnusedImports:
+    active: false
+  UnusedParameter:
     active: true
-  #  UnusedParameter:
-  #    active: true
-  #    allowedNames: 'ignored|expected'
+    allowedNames: 'ignored|expected'
   UnusedPrivateClass:
     active: true
   UnusedPrivateMember:
     active: true
     allowedNames: ''
-  #  UnusedPrivateProperty:
-  #    active: true
-  #    allowedNames: '_|ignored|expected|serialVersionUID'
+  UnusedPrivateProperty:
+    active: true
+    allowedNames: '_|ignored|expected|serialVersionUID'
   UseAnyOrNoneInsteadOfFind:
     active: true
   UseArrayLiteralsInAnnotations:
@@ -731,7 +748,7 @@ style:
     active: false
   UseIfInsteadOfWhen:
     active: false
-  #    ignoreWhenContainingVariableDeclaration: false
+    ignoreWhenContainingVariableDeclaration: false
   UseIsNullOrEmpty:
     active: true
   UseOrEmpty:

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,3 +17,5 @@ rootProject.name = "Taskify"
 include ':app'
 
 include ':core:domain'
+
+include ':core:test'

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,3 +15,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "Taskify"
 include ':app'
+
+include ':core:domain'


### PR DESCRIPTION
The `core/domain` gradle module is created (#10)

This PR also includes:
- `Text` wrapper class to work with string-resource and string on the domain layer.
- `EmailMatcher` interface to be able to match emails on the domain layer.
- `AuthPreferences`, and `OnboardingPreferences` interfaces.
- `FakeEmailMatcher`, `FakeAuthPreferences`, and `FakeOnboardingPreferences` classes for testing.