### PR TITLE
The `auth/domain` gradle module is created. (#23)

### DIFF
--- a/.idea/dictionaries/usmon.xml
+++ b/.idea/dictionaries/usmon.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
   <dictionary name="usmon">
     <words>
+      <w>couldn</w>
       <w>ktlint</w>
       <w>sexualized</w>
       <w>taskify</w>

--- a/auth/domain/build.gradle
+++ b/auth/domain/build.gradle
@@ -10,4 +10,6 @@ dependencies {
 
   implementation(libs.javax.inject)
   implementation(libs.coroutines.core)
+
+  androidTestImplementation project(":core:test")
 }

--- a/auth/domain/build.gradle
+++ b/auth/domain/build.gradle
@@ -8,5 +8,6 @@ android {
 dependencies {
   implementation project(":core:domain")
 
+  implementation(libs.javax.inject)
   implementation(libs.coroutines.core)
 }

--- a/auth/domain/build.gradle
+++ b/auth/domain/build.gradle
@@ -1,5 +1,6 @@
 apply from: "$rootDir/plugins/kotlin-android.gradle"
 apply from: "$rootDir/plugins/android-test.gradle"
+apply from: "$rootDir/plugins/kotlin-test.gradle"
 
 android {
   namespace "app.taskify.auth.domain"
@@ -11,5 +12,6 @@ dependencies {
   implementation(libs.javax.inject)
   implementation(libs.coroutines.core)
 
+  testImplementation project(":core:test")
   androidTestImplementation project(":core:test")
 }

--- a/auth/domain/build.gradle
+++ b/auth/domain/build.gradle
@@ -1,0 +1,10 @@
+apply from: "$rootDir/plugins/kotlin-android.gradle"
+apply from: "$rootDir/plugins/android-test.gradle"
+
+android {
+  namespace "app.taskify.auth.domain"
+}
+
+dependencies {
+  implementation project(":core:domain")
+}

--- a/auth/domain/build.gradle
+++ b/auth/domain/build.gradle
@@ -7,4 +7,6 @@ android {
 
 dependencies {
   implementation project(":core:domain")
+
+  implementation(libs.coroutines.core)
 }

--- a/auth/domain/src/androidTest/java/app/taskify/auth/domain/usecases/signin/SignInValidationUseCaseTest.kt
+++ b/auth/domain/src/androidTest/java/app/taskify/auth/domain/usecases/signin/SignInValidationUseCaseTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signin
+
+import app.taskify.auth.domain.R
+import app.taskify.core.domain.Text
+import app.taskify.core.test.matcher.FakeEmailMatcher
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+
+class SignInValidationUseCaseTest {
+
+  private lateinit var fakeEmailMatcher: FakeEmailMatcher
+  private lateinit var signInValidationUseCase: SignInValidationUseCase
+
+  private val defaultEmail = "hello@johndoe.com"
+  private val defaultPassword = "12345678"
+
+  @Before
+  fun setup() {
+    fakeEmailMatcher = FakeEmailMatcher()
+    signInValidationUseCase = SignInValidationUseCase(
+      emailMatcher = fakeEmailMatcher.mock,
+    )
+  }
+
+  @Test
+  fun emptyEmail_returnsSignInValidationResultWithEmptyEmailError() {
+    val email = ""
+    val password = defaultPassword
+
+    val validationResult = signInValidationUseCase(email, password)
+
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.emailError).isEqualTo(Text(R.string.empty_email))
+    fakeEmailMatcher.verifyEmailMatcherNeverCalled()
+  }
+
+  @Test
+  fun invalidEmail_returnsSignInValidationResultWithInvalidEmailError() {
+    val email = "hunter2"
+    val password = defaultPassword
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = false)
+    val validationResult = signInValidationUseCase(email, password)
+
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.emailError).isEqualTo(Text(R.string.invalid_email))
+  }
+
+  @Test
+  fun emptyPassword_returnsSignInValidationResultWithEmptyPasswordError() {
+    val email = defaultEmail
+    val password = ""
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signInValidationUseCase(email, password)
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.passwordError).isEqualTo(Text(R.string.empty_password))
+  }
+
+  @Test
+  fun validInputs_returnsNull() {
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signInValidationUseCase(email, password)
+
+    assertThat(validationResult).isNull()
+  }
+}

--- a/auth/domain/src/androidTest/java/app/taskify/auth/domain/usecases/signup/SignUpValidationUseCaseTest.kt
+++ b/auth/domain/src/androidTest/java/app/taskify/auth/domain/usecases/signup/SignUpValidationUseCaseTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signup
+
+import app.taskify.auth.domain.R.string
+import app.taskify.auth.domain.usecases.signup.SignUpValidationUseCase.Companion.MAX_DISPLAY_NAME_LENGTH
+import app.taskify.auth.domain.usecases.signup.SignUpValidationUseCase.Companion.MAX_PASSWORD_LENGTH
+import app.taskify.auth.domain.usecases.signup.SignUpValidationUseCase.Companion.MIN_DISPLAY_NAME_LENGTH
+import app.taskify.auth.domain.usecases.signup.SignUpValidationUseCase.Companion.MIN_PASSWORD_LENGTH
+import app.taskify.core.domain.Text
+import app.taskify.core.test.matcher.FakeEmailMatcher
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+
+class SignUpValidationUseCaseTest {
+
+  private lateinit var fakeEmailMatcher: FakeEmailMatcher
+  private lateinit var signUpValidationUseCase: SignUpValidationUseCase
+
+  private val defaultDisplayName = "John Doe"
+  private val defaultEmail = "hello@johndoe.com"
+  private val defaultPassword = "12345678"
+
+  @Before
+  fun setup() {
+    fakeEmailMatcher = FakeEmailMatcher()
+    signUpValidationUseCase = SignUpValidationUseCase(
+      emailMatcher = fakeEmailMatcher.mock,
+    )
+  }
+
+  @Test
+  fun emptyDisplayName_returnsSignUpValidationResultWithEmptyDisplayNameError() {
+    val displayName = ""
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.displayNameError).isEqualTo(Text(string.empty_display_name))
+  }
+
+  @Test
+  fun shortDisplayName_returnsSignUpValidationResultWithShortDisplayNameError() {
+    val displayName = "a".repeat(MIN_DISPLAY_NAME_LENGTH - 1)
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.displayNameError).isEqualTo(Text(string.short_display_name, MIN_DISPLAY_NAME_LENGTH))
+  }
+
+  @Test
+  fun longDisplayName_returnsSignUpValidationResultWithLongDisplayNameError() {
+    val displayName = "a".repeat(MAX_DISPLAY_NAME_LENGTH + 1)
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.displayNameError).isEqualTo(Text(string.long_display_name, MAX_DISPLAY_NAME_LENGTH))
+  }
+
+  @Test
+  fun emptyEmail_returnsSignUpValidationResultWithEmptyEmailError() {
+    val displayName = defaultDisplayName
+    val email = ""
+    val password = defaultPassword
+
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.emailError).isEqualTo(Text(string.empty_email))
+    fakeEmailMatcher.verifyEmailMatcherNeverCalled()
+  }
+
+  @Test
+  fun invalidEmail_returnsSignUpValidationResultWithInvalidEmailError() {
+    val displayName = defaultDisplayName
+    val email = "hunter2"
+    val password = defaultPassword
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = false)
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.emailError).isEqualTo(Text(string.invalid_email))
+  }
+
+  @Test
+  fun emptyPassword_returnsSignUpValidationResultWithEmptyPasswordError() {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = ""
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.passwordError).isEqualTo(Text(string.empty_password))
+  }
+
+  @Test
+  fun shortPassword_returnsSignUpValidationResultWithShortPasswordError() {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = "a".repeat(MIN_PASSWORD_LENGTH - 1)
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.passwordError).isEqualTo(Text(string.short_password, MIN_PASSWORD_LENGTH))
+  }
+
+  @Test
+  fun longPassword_returnsSignUpValidationResultWithLongPasswordError() {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = "a".repeat(MAX_PASSWORD_LENGTH + 1)
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+    assertThat(validationResult).isNotNull()
+    assertThat(validationResult?.passwordError).isEqualTo(Text(string.long_password, MAX_PASSWORD_LENGTH))
+  }
+
+  @Test
+  fun validInputs_returnsNull() {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeEmailMatcher.mockResultForEmail(email, isValidEmail = true)
+    val validationResult = signUpValidationUseCase(displayName, email, password)
+
+    assertThat(validationResult).isNull()
+  }
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/repository/AuthRepository.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/repository/AuthRepository.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface AuthRepository {
+  fun signIn(email: String, password: String): Flow<SignInResult>
+  fun signUp(email: String, password: String): Flow<SignUpResult>
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/repository/SignInResult.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/repository/SignInResult.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.repository
+
+import app.taskify.auth.domain.R
+import app.taskify.core.domain.Text
+
+sealed class SignInResult(val description: Text) {
+
+  object Authenticating : SignInResult(Text(R.string.authenticating))
+
+  object RetrievingProfile : SignInResult(Text(R.string.retrieving_profile))
+
+  object Authenticated : SignInResult(Text(R.string.authenticated))
+
+  sealed class Failure(description: Text) : SignInResult(description) {
+
+    object NoNetworkConnection : Failure(Text(R.string.no_network_connection))
+
+    object InvalidCredentials : Failure(Text(R.string.invalid_credentials))
+
+    data class Unknown(val throwable: Throwable) : Failure(Text(throwable.message ?: "Unknown error occurred."))
+  }
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/repository/SignUpResult.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/repository/SignUpResult.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.repository
+
+import app.taskify.auth.domain.R
+import app.taskify.core.domain.Text
+
+sealed class SignUpResult(val description: Text) {
+
+  object Authenticating : SignUpResult(Text(R.string.authenticating))
+
+  object SettingUpProfile : SignUpResult(Text(R.string.setting_up_profile))
+
+  object Authenticated : SignUpResult(Text(R.string.authenticated))
+
+  sealed class Failure(description: Text) : SignUpResult(description) {
+
+    object NoNetworkConnection : Failure(Text(R.string.no_network_connection))
+
+    object EmailAlreadyInUse : Failure(Text(R.string.email_already_in_use))
+
+    data class Unknown(val throwable: Throwable) : Failure(Text(throwable.message ?: "Unknown error occurred."))
+  }
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signin/SignInUseCase.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signin/SignInUseCase.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signin
+
+import app.taskify.auth.domain.repository.AuthRepository
+import app.taskify.auth.domain.repository.SignInResult
+import app.taskify.auth.domain.repository.SignInResult.Authenticated
+import app.taskify.auth.domain.repository.SignInResult.Authenticating
+import app.taskify.auth.domain.repository.SignInResult.Failure.InvalidCredentials
+import app.taskify.auth.domain.repository.SignInResult.Failure.NoNetworkConnection
+import app.taskify.auth.domain.repository.SignInResult.Failure.Unknown
+import app.taskify.auth.domain.repository.SignInResult.RetrievingProfile
+import app.taskify.auth.domain.util.InvalidCredentialsException
+import app.taskify.core.domain.exception.NetworkException
+import app.taskify.profile.domain.repository.ProfileRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class SignInUseCase @Inject constructor(
+  private val authRepository: AuthRepository,
+  private val profileRepository: ProfileRepository,
+) {
+
+  operator fun invoke(email: String, password: String): Flow<SignInResult> = flow {
+    emit(Authenticating)
+    val authResult = authRepository.signIn(email, password)
+    val userId = authResult.getOrElse { throwable ->
+      emit(throwable.toFailureSignInResult())
+      return@flow
+    }
+    emit(RetrievingProfile)
+    profileRepository.retrieveProfile(userId).onFailure { throwable ->
+      emit(throwable.toFailureSignInResult())
+      return@flow
+    }
+    emit(Authenticated)
+  }
+
+  // TODO: Handle all of the possible auth and profile exceptions here.
+  private fun Throwable.toFailureSignInResult(): SignInResult.Failure = when (this) {
+    is NetworkException -> NoNetworkConnection
+    is InvalidCredentialsException -> InvalidCredentials
+    else -> Unknown(this)
+  }
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signin/SignInValidationResult.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signin/SignInValidationResult.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signin
+
+import app.taskify.core.domain.Text
+
+data class SignInValidationResult(
+  val emailError: Text?,
+  val passwordError: Text?,
+)

--- a/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signin/SignInValidationUseCase.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signin/SignInValidationUseCase.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signin
+
+import app.taskify.auth.domain.R
+import app.taskify.core.domain.Text
+import app.taskify.core.domain.matcher.EmailMatcher
+import javax.inject.Inject
+
+class SignInValidationUseCase @Inject constructor(
+  private val emailMatcher: EmailMatcher,
+) {
+
+  operator fun invoke(email: String, password: String): SignInValidationResult? {
+    val emailError = getEmailError(email)
+    val passwordError = getPasswordError(password)
+    return SignInValidationResult(emailError, passwordError).takeIf {
+      emailError != null || passwordError != null
+    }
+  }
+
+  private fun getEmailError(email: String): Text? = when {
+    email.isEmpty() -> Text(R.string.empty_email)
+    !emailMatcher.matches(email) -> Text(R.string.invalid_email)
+    else -> null
+  }
+
+  private fun getPasswordError(password: String): Text? = when {
+    password.isEmpty() -> Text(R.string.empty_password)
+    else -> null
+  }
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signup/SignUpUseCase.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signup/SignUpUseCase.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signup
+
+import app.taskify.auth.domain.repository.AuthRepository
+import app.taskify.auth.domain.repository.SignUpResult
+import app.taskify.auth.domain.repository.SignUpResult.Authenticated
+import app.taskify.auth.domain.repository.SignUpResult.Authenticating
+import app.taskify.auth.domain.repository.SignUpResult.Failure.EmailAlreadyInUse
+import app.taskify.auth.domain.repository.SignUpResult.Failure.NoNetworkConnection
+import app.taskify.auth.domain.repository.SignUpResult.Failure.Unknown
+import app.taskify.auth.domain.repository.SignUpResult.SettingUpProfile
+import app.taskify.auth.domain.util.EmailAlreadyInUseException
+import app.taskify.core.domain.exception.NetworkException
+import app.taskify.profile.domain.repository.ProfileRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class SignUpUseCase @Inject constructor(
+  private val authRepository: AuthRepository,
+  private val profileRepository: ProfileRepository,
+) {
+
+  operator fun invoke(displayName: String, email: String, password: String): Flow<SignUpResult> = flow {
+    emit(Authenticating)
+    val authResult = authRepository.signUp(email, password)
+    val userId = authResult.getOrElse { throwable ->
+      emit(throwable.toFailureSignInResult())
+      return@flow
+    }
+    emit(SettingUpProfile)
+    profileRepository.setupProfile(displayName, email, userId).onFailure { throwable ->
+      emit(throwable.toFailureSignInResult())
+      return@flow
+    }
+    emit(Authenticated)
+  }
+
+  // TODO: Handle all of the possible auth and profile exceptions here.
+  private fun Throwable.toFailureSignInResult(): SignUpResult.Failure = when (this) {
+    is NetworkException -> NoNetworkConnection
+    is EmailAlreadyInUseException -> EmailAlreadyInUse
+    else -> Unknown(this)
+  }
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signup/SignUpValidationResult.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signup/SignUpValidationResult.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signup
+
+import app.taskify.core.domain.Text
+
+data class SignUpValidationResult(
+  val displayNameError: Text?,
+  val emailError: Text?,
+  val passwordError: Text?,
+)

--- a/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signup/SignUpValidationUseCase.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signup/SignUpValidationUseCase.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signup
+
+import app.taskify.auth.domain.R
+import app.taskify.core.domain.Text
+import app.taskify.core.domain.matcher.EmailMatcher
+import javax.inject.Inject
+
+class SignUpValidationUseCase @Inject constructor(
+  private val emailMatcher: EmailMatcher,
+) {
+
+  operator fun invoke(displayName: String, email: String, password: String): SignUpValidationResult? {
+    val displayNameError = getDisplayNameError(displayName)
+    val emailError = getEmailError(email)
+    val passwordError = getPasswordError(password)
+    return SignUpValidationResult(displayNameError, emailError, passwordError).takeIf {
+      displayNameError != null || emailError != null || passwordError != null
+    }
+  }
+
+  private fun getDisplayNameError(displayName: String): Text? = when {
+    displayName.isEmpty() -> Text(R.string.empty_display_name)
+    displayName.length < MIN_DISPLAY_NAME_LENGTH -> Text(R.string.short_display_name, MIN_DISPLAY_NAME_LENGTH)
+    displayName.length > MAX_DISPLAY_NAME_LENGTH -> Text(R.string.long_display_name, MAX_DISPLAY_NAME_LENGTH)
+    else -> null
+  }
+
+  private fun getEmailError(email: String): Text? = when {
+    email.isEmpty() -> Text(R.string.empty_email)
+    !emailMatcher.matches(email) -> Text(R.string.invalid_email)
+    else -> null
+  }
+
+  private fun getPasswordError(password: String): Text? = when {
+    password.isEmpty() -> Text(R.string.empty_password)
+    password.length < MIN_PASSWORD_LENGTH -> Text(R.string.short_password, MIN_PASSWORD_LENGTH)
+    password.length > MAX_PASSWORD_LENGTH -> Text(R.string.long_password, MAX_PASSWORD_LENGTH)
+    else -> null
+  }
+
+  internal companion object {
+    const val MIN_DISPLAY_NAME_LENGTH = 2
+    const val MAX_DISPLAY_NAME_LENGTH = 32
+    const val MIN_PASSWORD_LENGTH = 8
+    const val MAX_PASSWORD_LENGTH = 64
+  }
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/util/EmailAlreadyInUseException.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/util/EmailAlreadyInUseException.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package app.taskify.auth.domain.repository
+package app.taskify.auth.domain.util
 
-interface AuthRepository {
-  suspend fun signIn(email: String, password: String): Result<String>
-  suspend fun signUp(email: String, password: String): Result<String>
-}
+class EmailAlreadyInUseException @JvmOverloads constructor(
+  message: String? = null,
+  cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/auth/domain/src/main/java/app/taskify/auth/domain/util/InvalidCredentialsException.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/util/InvalidCredentialsException.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package app.taskify.auth.domain.repository
+package app.taskify.auth.domain.util
 
-interface AuthRepository {
-  suspend fun signIn(email: String, password: String): Result<String>
-  suspend fun signUp(email: String, password: String): Result<String>
-}
+class InvalidCredentialsException @JvmOverloads constructor(
+  message: String? = null,
+  cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/auth/domain/src/main/res/values/strings.xml
+++ b/auth/domain/src/main/res/values/strings.xml
@@ -22,4 +22,13 @@
   <string name="no_network_connection">Could not connect to the server. Please, check you internet connection!</string>
   <string name="invalid_credentials">Email or password went wrong. Please, try again.</string>
   <string name="email_already_in_use">This email is already in use. Please, use another one</string>
+
+  <string name="empty_display_name">Display name couldn\'t be empty</string>
+  <string name="empty_email">Email couldn\'t be empty</string>
+  <string name="empty_password">Password couldn\'t be empty</string>
+  <string name="short_display_name">Display name must contains at least %s characters</string>
+  <string name="long_display_name">Display name must contains at most %s characters</string>
+  <string name="invalid_email">Email is not valid. Please, enter a valid email address</string>
+  <string name="short_password">Password must contains at least %s characters.</string>
+  <string name="long_password">Password must contains at most %s characters.</string>
 </resources>

--- a/auth/domain/src/main/res/values/strings.xml
+++ b/auth/domain/src/main/res/values/strings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and limitations under the License.
+  -->
+
+<resources>
+  <string name="authenticating">Authenticating…</string>
+  <string name="authenticated">Authenticated</string>
+  <string name="retrieving_profile">Retrieving the profile info…</string>
+  <string name="setting_up_profile">Setting up the profile info…</string>
+  <string name="no_network_connection">Could not connect to the server. Please, check you internet connection!</string>
+  <string name="invalid_credentials">Email or password went wrong. Please, try again.</string>
+  <string name="email_already_in_use">This email is already in use. Please, use another one</string>
+</resources>

--- a/auth/domain/src/test/java/app/taskify/auth/domain/fake/FakeAuthRepository.kt
+++ b/auth/domain/src/test/java/app/taskify/auth/domain/fake/FakeAuthRepository.kt
@@ -13,9 +13,29 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package app.taskify.auth.domain.repository
+package app.taskify.auth.domain.fake
 
-interface AuthRepository {
-  suspend fun signIn(email: String, password: String): Result<String>
-  suspend fun signUp(email: String, password: String): Result<String>
+import app.taskify.auth.domain.repository.AuthRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+
+class FakeAuthRepository {
+
+  val mock: AuthRepository = mockk()
+
+  fun mockSignInResultForEmailAndPassword(
+    email: String,
+    password: String,
+    result: Result<String>,
+  ) {
+    coEvery { mock.signIn(email, password) } returns result
+  }
+
+  fun mockSignUpResultForEmailAndPassword(
+    email: String,
+    password: String,
+    result: Result<String>,
+  ) {
+    coEvery { mock.signUp(email, password) } returns result
+  }
 }

--- a/auth/domain/src/test/java/app/taskify/auth/domain/fake/FakeProfileRepository.kt
+++ b/auth/domain/src/test/java/app/taskify/auth/domain/fake/FakeProfileRepository.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.fake
+
+import app.taskify.profile.domain.repository.ProfileRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+
+class FakeProfileRepository {
+
+  val mock: ProfileRepository = mockk()
+
+  fun mockRetrieveProfileResultForEmailAndPassword(
+    userId: String,
+    result: Result<Unit>,
+  ) {
+    coEvery { mock.retrieveProfile(userId) } returns result
+  }
+
+  fun mockSetupProfileResultForEmailAndPassword(
+    displayName: String,
+    email: String,
+    userId: String,
+    result: Result<Unit>,
+  ) {
+    coEvery { mock.setupProfile(displayName, email, userId) } returns result
+  }
+
+  fun verifyRetrieveProfileNeverCalled() {
+    coVerify(exactly = 0) { mock.retrieveProfile(any()) }
+  }
+
+  fun verifySetupProfileNeverCalled() {
+    coVerify(exactly = 0) { mock.setupProfile(any(), any(), any()) }
+  }
+}

--- a/auth/domain/src/test/java/app/taskify/auth/domain/usecases/signin/SignInUseCaseTest.kt
+++ b/auth/domain/src/test/java/app/taskify/auth/domain/usecases/signin/SignInUseCaseTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signin
+
+import app.cash.turbine.test
+import app.taskify.auth.domain.fake.FakeAuthRepository
+import app.taskify.auth.domain.fake.FakeProfileRepository
+import app.taskify.auth.domain.repository.SignInResult.Authenticated
+import app.taskify.auth.domain.repository.SignInResult.Authenticating
+import app.taskify.auth.domain.repository.SignInResult.Failure.InvalidCredentials
+import app.taskify.auth.domain.repository.SignInResult.Failure.NoNetworkConnection
+import app.taskify.auth.domain.repository.SignInResult.Failure.Unknown
+import app.taskify.auth.domain.repository.SignInResult.RetrievingProfile
+import app.taskify.auth.domain.util.InvalidCredentialsException
+import app.taskify.core.domain.exception.NetworkException
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SignInUseCaseTest {
+
+  private lateinit var fakeAuthRepository: FakeAuthRepository
+  private lateinit var fakeProfileRepository: FakeProfileRepository
+  private lateinit var signInUseCase: SignInUseCase
+
+  private val defaultEmail = "hello@johndoe.com"
+  private val defaultPassword = "12345678"
+
+  @Before
+  fun setup() {
+    fakeAuthRepository = FakeAuthRepository()
+    fakeProfileRepository = FakeProfileRepository()
+    signInUseCase = SignInUseCase(
+      authRepository = fakeAuthRepository.mock,
+      profileRepository = fakeProfileRepository.mock,
+    )
+  }
+
+  @Test
+  fun `Network disconnected while authenticating, emits NoNetworkConnection result`() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val authResult = Result.failure<String>(NetworkException())
+
+    fakeAuthRepository.mockSignInResultForEmailAndPassword(email, password, authResult)
+
+    signInUseCase(email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(NoNetworkConnection)
+      awaitComplete()
+    }
+
+    fakeProfileRepository.verifyRetrieveProfileNeverCalled()
+  }
+
+  @Test
+  fun `Credentials was invalid while authenticating, emits InvalidCredentials result`() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val authResult = Result.failure<String>(InvalidCredentialsException())
+
+    fakeAuthRepository.mockSignInResultForEmailAndPassword(email, password, authResult)
+
+    signInUseCase(email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(InvalidCredentials)
+      awaitComplete()
+    }
+
+    fakeProfileRepository.verifyRetrieveProfileNeverCalled()
+  }
+
+  @Test
+  fun `Unexpected exception occurred while authenticating, emits Unknown result with the exception`() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val unexpectedException = RuntimeException()
+    val authResult = Result.failure<String>(unexpectedException)
+
+    fakeAuthRepository.mockSignInResultForEmailAndPassword(email, password, authResult)
+
+    signInUseCase(email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).run {
+        isInstanceOf(Unknown::class.java)
+        isEqualTo(Unknown(unexpectedException))
+      }
+      awaitComplete()
+    }
+
+    fakeProfileRepository.verifyRetrieveProfileNeverCalled()
+  }
+
+  @Test
+  fun `Network disconnected while retrieving the profile, emits NoNetworkConnection result`() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val userId = "userId"
+    val authResult = Result.success(userId)
+    val profileResult = Result.failure<Unit>(NetworkException())
+
+    fakeAuthRepository.mockSignInResultForEmailAndPassword(email, password, authResult)
+    fakeProfileRepository.mockRetrieveProfileResultForEmailAndPassword(userId, profileResult)
+
+    signInUseCase(email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(RetrievingProfile)
+      assertThat(awaitItem()).isEqualTo(NoNetworkConnection)
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun `Unexpected exception occurred while retrieving the profile emits Unknown result with the exception`() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val userId = "userId"
+    val unexpectedException = RuntimeException()
+    val authResult = Result.success(userId)
+    val profileResult = Result.failure<Unit>(unexpectedException)
+
+    fakeAuthRepository.mockSignInResultForEmailAndPassword(email, password, authResult)
+    fakeProfileRepository.mockRetrieveProfileResultForEmailAndPassword(userId, profileResult)
+
+    signInUseCase(email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(RetrievingProfile)
+      assertThat(awaitItem()).run {
+        isInstanceOf(Unknown::class.java)
+        isEqualTo(Unknown(unexpectedException))
+      }
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun `Everything was OK, emits Authenticated result`() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val userId = "userId"
+    val authResult = Result.success(userId)
+    val profileResult = Result.success(Unit)
+
+    fakeAuthRepository.mockSignInResultForEmailAndPassword(email, password, authResult)
+    fakeProfileRepository.mockRetrieveProfileResultForEmailAndPassword(userId, profileResult)
+
+    signInUseCase(email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(RetrievingProfile)
+      assertThat(awaitItem()).isEqualTo(Authenticated)
+      awaitComplete()
+    }
+  }
+}

--- a/auth/domain/src/test/java/app/taskify/auth/domain/usecases/signup/SignUpUseCaseTest.kt
+++ b/auth/domain/src/test/java/app/taskify/auth/domain/usecases/signup/SignUpUseCaseTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.domain.usecases.signup
+
+import app.cash.turbine.test
+import app.taskify.auth.domain.fake.FakeAuthRepository
+import app.taskify.auth.domain.fake.FakeProfileRepository
+import app.taskify.auth.domain.repository.SignUpResult.Authenticated
+import app.taskify.auth.domain.repository.SignUpResult.Authenticating
+import app.taskify.auth.domain.repository.SignUpResult.Failure.EmailAlreadyInUse
+import app.taskify.auth.domain.repository.SignUpResult.Failure.NoNetworkConnection
+import app.taskify.auth.domain.repository.SignUpResult.Failure.Unknown
+import app.taskify.auth.domain.repository.SignUpResult.SettingUpProfile
+import app.taskify.auth.domain.util.EmailAlreadyInUseException
+import app.taskify.core.domain.exception.NetworkException
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SignUpUseCaseTest {
+
+  private lateinit var fakeAuthRepository: FakeAuthRepository
+  private lateinit var fakeProfileRepository: FakeProfileRepository
+  private lateinit var signUpUseCase: SignUpUseCase
+
+  private val defaultDisplayName = "John Doe"
+  private val defaultEmail = "hello@johndoe.com"
+  private val defaultPassword = "12345678"
+
+  @Before
+  fun setup() {
+    fakeAuthRepository = FakeAuthRepository()
+    fakeProfileRepository = FakeProfileRepository()
+    signUpUseCase = SignUpUseCase(
+      authRepository = fakeAuthRepository.mock,
+      profileRepository = fakeProfileRepository.mock,
+    )
+  }
+
+  @Test
+  fun `Network disconnected while authenticating, emits NoNetworkConnection result`() = runTest {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = defaultPassword
+    val authResult = Result.failure<String>(NetworkException())
+
+    fakeAuthRepository.mockSignUpResultForEmailAndPassword(email, password, authResult)
+
+    signUpUseCase(displayName, email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(NoNetworkConnection)
+      awaitComplete()
+    }
+
+    fakeProfileRepository.verifySetupProfileNeverCalled()
+  }
+
+  @Test
+  fun `Email was already in use while authenticating, emits EmailAlreadyInUse result`() = runTest {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = defaultPassword
+    val authResult = Result.failure<String>(EmailAlreadyInUseException())
+
+    fakeAuthRepository.mockSignUpResultForEmailAndPassword(email, password, authResult)
+
+    signUpUseCase(displayName, email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(EmailAlreadyInUse)
+      awaitComplete()
+    }
+
+    fakeProfileRepository.verifySetupProfileNeverCalled()
+  }
+
+  @Test
+  fun `Unexpected exception occurred while authenticating, emits Unknown result with the exception`() = runTest {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = defaultPassword
+    val unexpectedException = RuntimeException()
+    val authResult = Result.failure<String>(unexpectedException)
+
+    fakeAuthRepository.mockSignUpResultForEmailAndPassword(email, password, authResult)
+
+    signUpUseCase(displayName, email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).run {
+        isInstanceOf(Unknown::class.java)
+        isEqualTo(Unknown(unexpectedException))
+      }
+      awaitComplete()
+    }
+
+    fakeProfileRepository.verifySetupProfileNeverCalled()
+  }
+
+  @Test
+  fun `Network disconnected while retrieving the profile, emits NoNetworkConnection result`() = runTest {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = defaultPassword
+    val userId = "userId"
+    val authResult = Result.success(userId)
+    val profileResult = Result.failure<Unit>(NetworkException())
+
+    fakeAuthRepository.mockSignUpResultForEmailAndPassword(email, password, authResult)
+    fakeProfileRepository.mockSetupProfileResultForEmailAndPassword(displayName, email, userId, profileResult)
+
+    signUpUseCase(displayName, email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(SettingUpProfile)
+      assertThat(awaitItem()).isEqualTo(NoNetworkConnection)
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun `Unexpected exception occurred while setting up the profile emits Unknown result with the exception`() = runTest {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = defaultPassword
+    val userId = "userId"
+    val unexpectedException = RuntimeException()
+    val authResult = Result.success(userId)
+    val profileResult = Result.failure<Unit>(unexpectedException)
+
+    fakeAuthRepository.mockSignUpResultForEmailAndPassword(email, password, authResult)
+    fakeProfileRepository.mockSetupProfileResultForEmailAndPassword(displayName, email, userId, profileResult)
+
+    signUpUseCase(displayName, email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(SettingUpProfile)
+      assertThat(awaitItem()).run {
+        isInstanceOf(Unknown::class.java)
+        isEqualTo(Unknown(unexpectedException))
+      }
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun `Everything was OK, emits Authenticated result`() = runTest {
+    val displayName = defaultDisplayName
+    val email = defaultEmail
+    val password = defaultPassword
+    val userId = "userId"
+    val authResult = Result.success(userId)
+    val profileResult = Result.success(Unit)
+
+    fakeAuthRepository.mockSignUpResultForEmailAndPassword(email, password, authResult)
+    fakeProfileRepository.mockSetupProfileResultForEmailAndPassword(displayName, email, userId, profileResult)
+
+    signUpUseCase(displayName, email, password).test {
+      assertThat(awaitItem()).isEqualTo(Authenticating)
+      assertThat(awaitItem()).isEqualTo(SettingUpProfile)
+      assertThat(awaitItem()).isEqualTo(Authenticated)
+      awaitComplete()
+    }
+  }
+}

--- a/core/domain/src/main/java/app/taskify/core/domain/exception/NetworkException.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/exception/NetworkException.kt
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package app.taskify.auth.domain.repository
+package app.taskify.core.domain.exception
 
-interface AuthRepository {
-  suspend fun signIn(email: String, password: String): Result<String>
-  suspend fun signUp(email: String, password: String): Result<String>
-}
+class NetworkException @JvmOverloads constructor(
+  message: String? = null,
+  cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/core/domain/src/main/java/app/taskify/profile/domain/repository/ProfileRepository.kt
+++ b/core/domain/src/main/java/app/taskify/profile/domain/repository/ProfileRepository.kt
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package app.taskify.auth.domain.repository
+package app.taskify.profile.domain.repository
 
-interface AuthRepository {
-  suspend fun signIn(email: String, password: String): Result<String>
-  suspend fun signUp(email: String, password: String): Result<String>
+interface ProfileRepository {
+
+  suspend fun retrieveProfile(userId: String): Result<Unit>
+
+  suspend fun setupProfile(
+    displayName: String,
+    email: String,
+    userId: String,
+  ): Result<Unit>
 }

--- a/core/presentation/src/main/java/app/taskify/core/presentation/BaseFragment.kt
+++ b/core/presentation/src/main/java/app/taskify/core/presentation/BaseFragment.kt
@@ -32,8 +32,8 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-abstract class BaseFragment<T : ViewDataBinding>(
-  @LayoutRes private val layoutId: Int = 0,
+abstract class BaseFragment<out T : ViewDataBinding>(
+  @LayoutRes private val layoutId: Int,
 ) : Fragment(layoutId) {
 
   private var _binding: T? = null
@@ -54,7 +54,7 @@ abstract class BaseFragment<T : ViewDataBinding>(
     _binding = null
   }
 
-  fun <T> Flow<T>.lifecycleAwareCollect(collector: FlowCollector<T>) {
+  protected fun <T> Flow<T>.lifecycleAwareCollect(collector: FlowCollector<T>) {
     viewLifecycleOwner.lifecycleScope.launch {
       repeatOnLifecycle(Lifecycle.State.STARTED) {
         collect(collector)
@@ -62,7 +62,7 @@ abstract class BaseFragment<T : ViewDataBinding>(
     }
   }
 
-  fun <T> Flow<T>.lifecycleAwareCollectLatest(collector: (T) -> Unit) {
+  protected fun <T> Flow<T>.lifecycleAwareCollectLatest(collector: (T) -> Unit) {
     viewLifecycleOwner.lifecycleScope.launch {
       repeatOnLifecycle(Lifecycle.State.STARTED) {
         collectLatest(collector)

--- a/core/test/src/main/java/app/taskify/core/test/matcher/FakeEmailMatcher.kt
+++ b/core/test/src/main/java/app/taskify/core/test/matcher/FakeEmailMatcher.kt
@@ -27,9 +27,9 @@ class FakeEmailMatcher {
 
   fun mockResultForEmail(
     email: CharSequence,
-    result: Boolean,
+    isValidEmail: Boolean,
   ) {
-    every { mock.matches(email) } returns result
+    every { mock.matches(email) } returns isValidEmail
   }
 
   fun verifyEmailMatcherNeverCalled() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 
 junit = { group = "junit", name = "junit", version = "4.13.2" }
-mockk = { group = "io.mockk", name = "mockk-android", version = "1.13.5" }
+mockk = { group = "io.mockk", name = "mockk-android", version = "1.13.2" }
 truth = { group = "com.google.truth", name = "truth", version = "1.1.3" }
 turbine = { group = "app.cash.turbine", name = "turbine", version = "0.12.3" }
 

--- a/plugins/android-test.gradle
+++ b/plugins/android-test.gradle
@@ -12,4 +12,5 @@ dependencies {
   androidTestImplementation(libs.testExtJunit)
   androidTestImplementation(libs.espressoCore)
   androidTestImplementation(libs.testRunner)
+  androidTestImplementation(libs.coroutines.test)
 }

--- a/plugins/config/detekt.yml
+++ b/plugins/config/detekt.yml
@@ -573,7 +573,6 @@ style:
     values:
       - 'FIXME:'
       - 'STOPSHIP:'
-      - 'TODO:'
     allowedPatterns: ''
     customMessage: ''
   ForbiddenImport:

--- a/plugins/kotlin-test.gradle
+++ b/plugins/kotlin-test.gradle
@@ -3,4 +3,5 @@ dependencies {
   testImplementation(libs.mockk)
   testImplementation(libs.truth)
   testImplementation(libs.turbine)
+  testImplementation(libs.coroutines.test)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ rootProject.name = "Taskify"
 include ':app'
 
 include ':core:domain'
+include ':core:presentation'
 
 include ':core:test'
-include ':core:presentation'
+include ':auth:domain'

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,5 +20,4 @@ include ':core:domain'
 include ':core:presentation'
 include ':core:test'
 
-
 include ':auth:domain'

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ include ':app'
 
 include ':core:domain'
 include ':core:presentation'
-
 include ':core:test'
+
+
 include ':auth:domain'


### PR DESCRIPTION
The `auth/domain` gradle module is created (#23).

The following classes are created:
- AuthRepository
- ProfileRepository
- SignInResuls
- SignUpResult
- SignInValidationResult
- SignUpValidationResult
- SignInUseCase
- SignUpUseCase
- SignInValidationUseCase
- SignUpValidationUseCase

And, the following classes are created to test them:
- FakeAuthRepository
- FakeProfileRepository
- SignInUseCaseTest
- SignUpUseCaseTest
- SignInValidationUseCaseTest
- SignUpValidationUseCaseTest