### PR TITLE
The `core/data` gradle module is created (#10)

### DIFF
--- a/auth/presentation/src/test/java/app/taskify/auth/presentation/signin/SignInViewModelTest.kt
+++ b/auth/presentation/src/test/java/app/taskify/auth/presentation/signin/SignInViewModelTest.kt
@@ -24,7 +24,7 @@ import app.taskify.auth.domain.usecases.signin.SignInValidationResult.EmailError
 import app.taskify.auth.domain.usecases.signin.SignInValidationResult.PasswordError
 import app.taskify.auth.presentation.signin.SignInNavigationEvent.NavigateToMain
 import app.taskify.core.domain.Text
-import app.taskify.core.test.CoroutinesTestRule
+import app.taskify.core.test.CoroutinesTestScopeRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -35,7 +35,7 @@ import org.junit.Test
 class SignInViewModelTest {
 
   @get:Rule
-  val coroutineTestRule = CoroutinesTestRule()
+  val coroutineTestScopeRule = CoroutinesTestScopeRule()
 
   private lateinit var viewModelRobot: SignInViewModelRobot
 

--- a/auth/presentation/src/test/java/app/taskify/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/presentation/src/test/java/app/taskify/auth/presentation/signup/SignUpViewModelTest.kt
@@ -29,7 +29,7 @@ import app.taskify.auth.domain.usecases.signup.SignUpValidationUseCase.Companion
 import app.taskify.auth.domain.usecases.signup.SignUpValidationUseCase.Companion.MIN_PASSWORD_LENGTH
 import app.taskify.auth.presentation.signup.SignUpNavigationEvent.NavigateToMain
 import app.taskify.core.domain.Text
-import app.taskify.core.test.CoroutinesTestRule
+import app.taskify.core.test.CoroutinesTestScopeRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -40,7 +40,7 @@ import org.junit.Test
 class SignUpViewModelTest {
 
   @get:Rule
-  val coroutineTestRule = CoroutinesTestRule()
+  val coroutineTestScopeRule = CoroutinesTestScopeRule()
 
   private lateinit var viewModelRobot: SignUpViewModelRobot
 

--- a/core/data/build.gradle
+++ b/core/data/build.gradle
@@ -1,0 +1,10 @@
+apply from: "$rootDir/plugins/kotlin-android.gradle"
+apply from: "$rootDir/plugins/hilt-android.gradle"
+
+android {
+  namespace "app.taskify.core.data"
+}
+
+dependencies {
+  implementation project(":core:domain")
+}

--- a/core/data/build.gradle
+++ b/core/data/build.gradle
@@ -7,4 +7,6 @@ android {
 
 dependencies {
   implementation project(":core:domain")
+
+  implementation(libs.datastore)
 }

--- a/core/data/src/main/java/app/taskify/core/data/PreferencesDatastore.kt
+++ b/core/data/src/main/java/app/taskify/core/data/PreferencesDatastore.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package app.taskify.core.data.preferences
+package app.taskify.core.data
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences

--- a/core/data/src/main/java/app/taskify/core/data/inject/CoreDataModule.kt
+++ b/core/data/src/main/java/app/taskify/core/data/inject/CoreDataModule.kt
@@ -16,8 +16,10 @@
 package app.taskify.core.data.inject
 
 import app.taskify.core.data.matcher.AndroidEmailMatcher
+import app.taskify.core.data.preferences.DataStoreOnboardingPreferences
 import app.taskify.core.data.preferences.DataStoreProfilePreferences
 import app.taskify.core.domain.matcher.EmailMatcher
+import app.taskify.core.domain.preferences.OnboardingPreferences
 import app.taskify.core.domain.preferences.ProfilePreferences
 import dagger.Binds
 import dagger.Module
@@ -34,4 +36,7 @@ interface CoreDataModule {
 
   @Binds
   fun bindProfilePreferences(target: DataStoreProfilePreferences): ProfilePreferences
+
+  @Binds
+  fun bindOnboardingPreferences(target: DataStoreOnboardingPreferences): OnboardingPreferences
 }

--- a/core/data/src/main/java/app/taskify/core/data/inject/CoreDataModule.kt
+++ b/core/data/src/main/java/app/taskify/core/data/inject/CoreDataModule.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.data.inject
+
+import app.taskify.core.data.matcher.AndroidEmailMatcher
+import app.taskify.core.domain.matcher.EmailMatcher
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@Suppress("unused")
+@InstallIn(SingletonComponent::class)
+interface CoreDataModule {
+
+  @Binds
+  fun AndroidEmailMatcher.bind(): EmailMatcher
+}

--- a/core/data/src/main/java/app/taskify/core/data/inject/CoreDataModule.kt
+++ b/core/data/src/main/java/app/taskify/core/data/inject/CoreDataModule.kt
@@ -16,7 +16,9 @@
 package app.taskify.core.data.inject
 
 import app.taskify.core.data.matcher.AndroidEmailMatcher
+import app.taskify.core.data.preferences.DataStoreProfilePreferences
 import app.taskify.core.domain.matcher.EmailMatcher
+import app.taskify.core.domain.preferences.ProfilePreferences
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -28,5 +30,8 @@ import dagger.hilt.components.SingletonComponent
 interface CoreDataModule {
 
   @Binds
-  fun AndroidEmailMatcher.bind(): EmailMatcher
+  fun bindEmailMatcher(target: AndroidEmailMatcher): EmailMatcher
+
+  @Binds
+  fun bindProfilePreferences(target: DataStoreProfilePreferences): ProfilePreferences
 }

--- a/core/data/src/main/java/app/taskify/core/data/inject/DatastoreModule.kt
+++ b/core/data/src/main/java/app/taskify/core/data/inject/DatastoreModule.kt
@@ -17,7 +17,7 @@ package app.taskify.core.data.inject
 
 import android.content.Context
 import androidx.datastore.preferences.preferencesDataStore
-import app.taskify.core.data.preferences.PreferencesDataStore
+import app.taskify.core.data.PreferencesDataStore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/core/data/src/main/java/app/taskify/core/data/inject/DatastoreModule.kt
+++ b/core/data/src/main/java/app/taskify/core/data/inject/DatastoreModule.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.data.inject
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStore
+import app.taskify.core.data.preferences.PreferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatastoreModule {
+
+  private const val DATASTORE_PREFERENCES_NAME = "app.taskify:preferences"
+
+  private val Context.dataStore: PreferencesDataStore by preferencesDataStore(DATASTORE_PREFERENCES_NAME)
+
+  @Singleton
+  @Provides
+  fun provideDatastoreInstance(@ApplicationContext context: Context): PreferencesDataStore = context.dataStore
+}

--- a/core/data/src/main/java/app/taskify/core/data/matcher/AndroidEmailMatcher.kt
+++ b/core/data/src/main/java/app/taskify/core/data/matcher/AndroidEmailMatcher.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.data.matcher
+
+import android.util.Patterns
+import app.taskify.core.domain.matcher.EmailMatcher
+import javax.inject.Inject
+
+class AndroidEmailMatcher @Inject constructor() : EmailMatcher {
+
+  override fun matches(email: CharSequence): Boolean {
+    return Patterns.EMAIL_ADDRESS.matcher(email).matches()
+  }
+}

--- a/core/data/src/main/java/app/taskify/core/data/preferences/DataStoreOnboardingPreferences.kt
+++ b/core/data/src/main/java/app/taskify/core/data/preferences/DataStoreOnboardingPreferences.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.data.preferences
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import app.taskify.core.data.PreferencesDataStore
+import app.taskify.core.domain.preferences.OnboardingPreferences
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class DataStoreOnboardingPreferences @Inject constructor(
+  private val dataStore: PreferencesDataStore,
+) : OnboardingPreferences {
+
+  override val isOnboardingCompleted: Flow<Boolean> = dataStore.data.map { preferences ->
+    preferences[onboardingCompletedKey] ?: false
+  }
+
+  override suspend fun setOnboardingCompleted(isOnboardingCompleted: Boolean) {
+    dataStore.edit { preferences ->
+      preferences[onboardingCompletedKey] = isOnboardingCompleted
+    }
+  }
+
+  private companion object {
+    val onboardingCompletedKey = booleanPreferencesKey("is_onboarding_completed_key")
+  }
+}

--- a/core/data/src/main/java/app/taskify/core/data/preferences/DataStoreProfilePreferences.kt
+++ b/core/data/src/main/java/app/taskify/core/data/preferences/DataStoreProfilePreferences.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.data.preferences
+
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import app.taskify.core.data.PreferencesDataStore
+import app.taskify.core.data.setOrRemove
+import app.taskify.core.domain.preferences.ProfilePreferences
+import app.taskify.core.domain.preferences.ProfilePreferences.Profile
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class DataStoreProfilePreferences @Inject constructor(
+  private val dataStore: PreferencesDataStore,
+) : ProfilePreferences {
+
+  override val profile: Flow<Profile?> = dataStore.data.map { preferences ->
+    Profile(preferences[displayNameKey], preferences[emailKey], preferences[userIdKey])
+  }
+
+  override val isAuthenticated: Flow<Boolean> = profile.map { it != null }
+
+  override suspend fun setProfile(displayName: String?, email: String?, userId: String?) {
+    dataStore.edit { preferences ->
+      preferences.setOrRemove(displayNameKey, displayName)
+      preferences.setOrRemove(emailKey, email)
+      preferences.setOrRemove(userIdKey, userId)
+    }
+  }
+
+  private companion object {
+    val displayNameKey = stringPreferencesKey("display_name_pref_key")
+    val emailKey = stringPreferencesKey("email_pref_key")
+    val userIdKey = stringPreferencesKey("user_id_pref_key")
+  }
+}

--- a/core/data/src/main/java/app/taskify/core/data/preferences/PreferencesDatastore.kt
+++ b/core/data/src/main/java/app/taskify/core/data/preferences/PreferencesDatastore.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.core.data.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.Preferences.Key
+
+typealias PreferencesDataStore = DataStore<Preferences>
+
+@JvmSynthetic
+internal fun <T> MutablePreferences.setOrRemove(key: Key<T>, value: T?) {
+  if (value != null) set(key, value) else remove(key)
+}

--- a/core/domain/src/main/java/app/taskify/core/domain/preferences/ProfilePreferences.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/preferences/ProfilePreferences.kt
@@ -20,13 +20,13 @@ import kotlinx.coroutines.flow.Flow
 
 interface ProfilePreferences {
 
-  val isAuthenticated: Flow<Boolean>
-
   val profile: Flow<Profile?>
+
+  val isAuthenticated: Flow<Boolean>
 
   suspend fun setProfile(displayName: String?, email: String?, userId: String?)
 
-  suspend fun setProfile(profile: Profile) = setProfile(profile.displayName, profile.email, profile.userId)
+  suspend fun setProfile(profile: Profile?) = setProfile(profile?.displayName, profile?.email, profile?.userId)
 
   data class Profile(
     val displayName: String?,

--- a/core/domain/src/main/java/app/taskify/core/domain/preferences/ProfilePreferences.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/preferences/ProfilePreferences.kt
@@ -15,11 +15,22 @@
 
 package app.taskify.core.domain.preferences
 
+import java.io.Serializable
 import kotlinx.coroutines.flow.Flow
 
-interface AuthPreferences {
+interface ProfilePreferences {
 
   val isAuthenticated: Flow<Boolean>
 
-  suspend fun setAuthenticated(isAuthenticated: Boolean)
+  val profile: Flow<Profile?>
+
+  suspend fun setProfile(displayName: String?, email: String?, userId: String?)
+
+  suspend fun setProfile(profile: Profile) = setProfile(profile.displayName, profile.email, profile.userId)
+
+  data class Profile(
+    val displayName: String?,
+    val email: String?,
+    val userId: String?,
+  ) : Serializable
 }

--- a/core/test/src/main/java/app/taskify/core/test/CoroutinesTestScopeRule.kt
+++ b/core/test/src/main/java/app/taskify/core/test/CoroutinesTestScopeRule.kt
@@ -13,31 +13,29 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package app.taskify.core.test
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class CoroutinesTestRule(
-  private val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher(),
-) : TestWatcher() {
+class CoroutinesTestScopeRule(
+  private val testDispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher(), CoroutineScope by TestScope(testDispatcher) {
 
   override fun starting(description: Description) {
-    super.starting(description)
     Dispatchers.setMain(testDispatcher)
   }
 
   override fun finished(description: Description) {
-    super.finished(description)
     Dispatchers.resetMain()
-    testDispatcher.cleanupTestCoroutines()
   }
 }

--- a/core/test/src/main/java/app/taskify/core/test/preferences/FakeProfilePreferences.kt
+++ b/core/test/src/main/java/app/taskify/core/test/preferences/FakeProfilePreferences.kt
@@ -15,22 +15,31 @@
 
 package app.taskify.core.test.preferences
 
-import app.taskify.core.domain.preferences.AuthPreferences
+import app.taskify.core.domain.preferences.ProfilePreferences
+import app.taskify.core.domain.preferences.ProfilePreferences.Profile
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 
 @Suppress("unused")
-class FakeAuthPreferences {
+class FakeProfilePreferences {
 
-  val mock: AuthPreferences = mockk(relaxUnitFun = true)
+  val mock: ProfilePreferences = mockk(relaxUnitFun = true)
 
   fun mockAuthenticatedForResult(result: Boolean) {
     every { mock.isAuthenticated } answers { flowOf(result) }
   }
 
+  fun mockProfileForResult(profile: Profile) {
+    every { mock.profile } answers { flowOf(profile) }
+  }
+
   fun verifyIsAuthenticatedNeverCalled() {
     verify(exactly = 0) { mock.isAuthenticated }
+  }
+
+  fun verifyProfileNeverCalled() {
+    verify(exactly = 0) { mock.profile }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ appcompat = "1.6.1"
 material = "1.8.0"
 coroutines = "1.6.4"
 fragment = "1.5.7"
+datastore = "1.0.0"
 
 [libraries]
 desugar = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar" }
@@ -25,6 +26,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
+datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 mockk = { group = "io.mockk", name = "mockk-android", version = "1.13.2" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,9 +16,8 @@ dependencyResolutionManagement {
 rootProject.name = "Taskify"
 include ':app'
 
-include ':core:domain'
-include ':core:presentation'
-include ':core:test'
+// Core modules
+include(':core:data', ':core:domain', ':core:presentation', ':core:test')
 
-include ':auth:domain'
-include ':auth:presentation'
+// Auth feature
+include(':auth:domain', ':auth:presentation')


### PR DESCRIPTION
The `core/data` gradle module is created to put android specific, local, or remote data source implementations.

The following classes are created:
- CoreDataModule
- DataStoreModule
- AndroidEmailMatcher
- DataStoreProfilePreferences
- DataStoreOnboardingPreferences