### PR TITLE
Additional features/checks are added to `Danger`

### DIFF
--- a/.idea/dictionaries/usmon.xml
+++ b/.idea/dictionaries/usmon.xml
@@ -3,9 +3,12 @@
     <words>
       <w>couldn</w>
       <w>ktlint</w>
+      <w>mergeable</w>
+      <w>readlines</w>
       <w>sexualized</w>
       <w>signin</w>
       <w>signup</w>
+      <w>tada</w>
       <w>taskify</w>
     </words>
   </dictionary>

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,32 +1,103 @@
-message "Thanks @#{github.pr_author}. Keep coding!"
+# Skip Danger if there is a #skip_danger tag.
+if github.pr_body.include?("#skip_danger")
+  message "Skipping Danger due to #skip_danger tag"
+  return
+end
 
+# Make it more obvious that a PR is a work in progress and shouldn't be merged yet.
+if github.pr_json["mergeable_state"] == "draft"
+  message "Skipping Danger since PR is classed as Draft"
+  return
+elsif github.pr_title.include? "[WIP]"
+  warn "Skipping Danger since PR is classed as WIP"
+  return
+end
+
+# Thank if the contributor is external.
+if github.pr_author != "usdaves"
+  message "Thanks @#{github.pr_author}! :tada:"
+end
+
+# Check if PR has no or small description.
 if github.pr_body.length == 0
-    fail "Please provide a summary in the Pull Request description."
+  fail "Please provide a summary in the Pull Request description"
+elsif github.pr_body.length < 50 && git.lines_of_code > 50
+  warn "Please provide a little more detailed summary in the Pull Request description"
 end
 
-if git.lines_of_code > 500
-    warn "Please consider breaking up this pull request."
-end
-
+# Check if PR has no or more than 5 labels.
 if github.pr_labels.empty?
-    warn "Please add labels to this PR."
+  warn "Please add labels to this PR."
+elsif github.pr_labels.count > 5
+  warn "This PR has more than 5 labels, consider removing some of them"
 end
 
+# Warn when there is a big PR
+if git.lines_of_code > 500
+  warn "Please consider breaking up this PR into smaller ones."
+elsif git.lines_of_code > 1000
+  fail "PR has more than 1000 lines of modified code. Break it up into smaller ones."
+end
+
+# Notify the contributor if they can remove the code.
 if git.deletions > git.insertions
-    message  "🎉 Code Cleanup!"
+  message  "Code Cleanup! 🎉"
 end
 
-# Notify of outdated dependencies
-dependencyUpdatesHeader = "The following dependencies have later milestone versions:"
-dependencyReportsFile = "build/dependencyUpdates/report.txt"
+# If these are all empty something has gone wrong, better to raise it in a comment.
+if git.modified_files.empty? && git.added_files.empty? && git.deleted_files.empty?
+  fail "This PR has no changes at all, this is likely an issue during development."
+end
 
-# Due to the formatting of this output file, we first check if there are any dependencies
-# by looking for a `->` arrow, then we check for the relevant headers. We do this to handle a case
-# where there are no app dependencies but there are Gradle dependencies.
-hasDependencyUpdatesHeader = File.readlines(dependencyReportsFile).grep(/#{dependencyUpdatesHeader}/).any?
+functionalChanges = git.modified_files.include? "**/main/**/*.kt"
+testChanges = git.modified_files.include? "**/test/**/*.kt"
+androidTestChanges = git.modified_files.include? "**/androidTest/**/*.kt"
+docsChanges = git.modified_files.include? "*.md"
 
-if hasDependencyUpdatesHeader
-  file = File.open(dependencyReportsFile, "rb").read
-  index = file.index(dependencyUpdatesHeader)
-  message file.slice(index..-1)
+# Warn when the application source code has been modified, but the test sources have not.
+if functionalChanges && !(testChanges || androidTestChanges)
+  warn "Looks like this PR contains functional changes without a corresponding test"
+end
+
+# Thank when the documentation changes
+if docsChanges
+  message "Thank you for making documentation better :heart:!"
+end
+
+# Notify when we have outdated dependencies.
+# In this case, gradle versions plugin have to be applied to the root project.
+dependencyUpdatesReportFilePath = "build/dependencyUpdates/report.txt"
+
+exceedDependenciesHeader = "The following dependencies exceed the version found at the milestone revision level:"
+upgradeDependenciesHeader = "The following dependencies have later milestone versions:"
+undeclaredDependenciesHeader = "Failed to compare versions for the following dependencies because they were declared without version:"
+unresolvedDependenciesHeader = "Failed to determine the latest version for the following dependencies (use --info for details):"
+gradleUpdatesHeader = "Gradle current updates:"
+
+dependencyUpdatesReportLines = File.readlines(dependencyUpdatesReportFilePath)
+
+areExceedDependenciesAvailable = dependencyUpdatesReportLines.grep(/#{exceedDependenciesHeader}/).any?
+areUpgradeDependenciesAvailable = dependencyUpdatesReportLines.grep(/#{upgradeDependenciesHeader}/).any?
+areUndeclaredDependenciesAvailable = dependencyUpdatesReportLines.grep(/#{undeclaredDependenciesHeader}/).any?
+areUnresolvedDependenciesAvailable = dependencyUpdatesReportLines.grep(/#{unresolvedDependenciesHeader}/).any?
+areGradleUpdatesAvailable = !dependencyUpdatesReportLines.find { |line| line =~ / - Gradle: \[/ && line =~ /\: UP-TO-DATE\]/ }
+
+if areExceedDependenciesAvailable || areUpgradeDependenciesAvailable || areUndeclaredDependenciesAvailable || areUnresolvedDependenciesAvailable || areGradleUpdatesAvailable
+  reportFileContent = File.open(dependencyUpdatesReportFilePath, "rb").read
+
+  beginning = if areExceedDependenciesAvailable
+      reportFileContent.index(exceedDependenciesHeader)
+    elsif areUpgradeDependenciesAvailable
+      reportFileContent.index(upgradeDependenciesHeader)
+    elsif areUndeclaredDependenciesAvailable
+      reportFileContent.index(undeclaredDependenciesHeader)
+    elsif areUnresolvedDependenciesAvailable
+      reportFileContent.index(unresolvedDependenciesHeader)
+    elsif areGradleUpdatesAvailable
+      reportFileContent.index(gradleUpdatesHeader)
+    end
+
+  ending = areGradleUpdatesAvailable ? 0 : reportFileContent.index(gradleUpdatesHeader)
+
+  message reportFileContent.slice(beginning..(ending - 1))
 end

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,4 +40,4 @@ android.nonTransitiveRClass=true
 # by caching the result of the configuration phase and reusing this for subsequent builds.
 # Using the configuration cache, Gradle can skip the configuration phase entirely
 # when nothing that affects the build configuration, such as build scripts, has changed.
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-gradle = "8.0.0"
+gradle = "8.0.1"
 kotlin = "1.8.21"
 kotlinter = "3.14.0"
 detekt = "1.23.0-RC2"
 versions = "0.46.0"
-hilt = "2.45"
+hilt = "2.46"
 
 desugar = "2.0.3"
 core-ktx = "1.10.0"


### PR DESCRIPTION
Added features/checks are added to `Danger`

- The `#skip__danger` tag to skip the `Danger` checks.
- Skip danger if the PR is classed as Draft or WIP.
- Say thanks only to external contributors.
- Fail when the PR doesn't have a description, and Warn when the PR description has less than 50 characters and changed lines of code are more than 50 lines.
- Warn when the PR has no or more than 5 labels.
- Warn when the PR has more than 500 lines of changed code, and Fail if the PR has more than 1000 lines of changed code.
- Warn if the PR has functional changes without changed tests.