### PR TITLE
The `ProdAuthRepository` class is created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ captures/
 
 # Do not commit firebase config
 google-services.json
+
+# To tun Danger locally, Do not commit.
+/Gemfile.lock

--- a/Dangerfile
+++ b/Dangerfile
@@ -49,10 +49,12 @@ if git.modified_files.empty? && git.added_files.empty? && git.deleted_files.empt
   fail "This PR has no changes at all, this is likely an issue during development."
 end
 
-functionalChanges = git.modified_files.include? "**/main/**/*.kt"
-testChanges = git.modified_files.include? "**/test/**/*.kt"
-androidTestChanges = git.modified_files.include? "**/androidTest/**/*.kt"
-docsChanges = git.modified_files.include? "*.md"
+fileChanges = (git.added_files + git.modified_files + git.deleted_files)
+
+functionalChanges = fileChanges.include? "**/main/**/*.kt"
+testChanges = fileChanges.include? "**/test/**/*.kt"
+androidTestChanges = fileChanges.include? "**/androidTest/**/*.kt"
+docsChanges = fileChanges.include? "*.md"
 
 # Warn when the application source code has been modified, but the test sources have not.
 if functionalChanges && !(testChanges || androidTestChanges)

--- a/auth/data/build.gradle
+++ b/auth/data/build.gradle
@@ -6,5 +6,7 @@ android {
 
 dependencies {
   implementation project(":auth:domain")
+  implementation project(":core:domain")
   implementation(libs.javax.inject)
+  implementation(libs.firebase.auth)
 }

--- a/auth/data/build.gradle
+++ b/auth/data/build.gradle
@@ -1,4 +1,5 @@
 apply from: "$rootDir/plugins/kotlin-android.gradle"
+apply from: "$rootDir/plugins/android-test.gradle"
 
 android {
   namespace 'app.taskify.auth.data'

--- a/auth/data/src/androidTest/java/app/taskify/auth/data/fake/FakeFirebaseAuth.kt
+++ b/auth/data/src/androidTest/java/app/taskify/auth/data/fake/FakeFirebaseAuth.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.data.fake
+
+import com.google.firebase.auth.FirebaseAuth
+import io.mockk.every
+import io.mockk.mockk
+
+class FakeFirebaseAuth {
+
+  val mock: FirebaseAuth = mockk()
+
+  fun mockSignInUserIdForCredentials(
+    email: String,
+    password: String,
+    userId: String,
+  ) {
+    every {
+      mock.signInWithEmailAndPassword(email, password).isComplete
+    } returns true
+    every {
+      mock.signInWithEmailAndPassword(email, password).exception
+    } returns null
+    every {
+      mock.signInWithEmailAndPassword(email, password).isCanceled
+    } returns false
+    every {
+      mock.signInWithEmailAndPassword(email, password).result.user?.uid
+    } answers { userId }
+  }
+
+  fun throwWhenSignInCalledWithCredentials(
+    email: String,
+    password: String,
+    exception: Exception,
+  ) {
+    every {
+      mock.signInWithEmailAndPassword(email, password)
+    } throws exception
+  }
+
+  fun mockSignUpUserIdForCredentials(
+    email: String,
+    password: String,
+    userId: String,
+  ) {
+    every {
+      mock.createUserWithEmailAndPassword(email, password).isComplete
+    } returns true
+    every {
+      mock.createUserWithEmailAndPassword(email, password).exception
+    } returns null
+    every {
+      mock.createUserWithEmailAndPassword(email, password).isCanceled
+    } returns false
+    every {
+      mock.createUserWithEmailAndPassword(email, password).result.user?.uid
+    } answers { userId }
+  }
+
+  fun throwWhenSignUpCalledWithCredentials(
+    email: String,
+    password: String,
+    exception: Exception,
+  ) {
+    every {
+      mock.createUserWithEmailAndPassword(email, password)
+    } throws exception
+  }
+}

--- a/auth/data/src/androidTest/java/app/taskify/auth/data/fake/FakeFirebaseAuth.kt
+++ b/auth/data/src/androidTest/java/app/taskify/auth/data/fake/FakeFirebaseAuth.kt
@@ -28,18 +28,10 @@ class FakeFirebaseAuth {
     password: String,
     userId: String,
   ) {
-    every {
-      mock.signInWithEmailAndPassword(email, password).isComplete
-    } returns true
-    every {
-      mock.signInWithEmailAndPassword(email, password).exception
-    } returns null
-    every {
-      mock.signInWithEmailAndPassword(email, password).isCanceled
-    } returns false
-    every {
-      mock.signInWithEmailAndPassword(email, password).result.user?.uid
-    } answers { userId }
+    every { mock.signInWithEmailAndPassword(email, password).isComplete } returns true
+    every { mock.signInWithEmailAndPassword(email, password).exception } returns null
+    every { mock.signInWithEmailAndPassword(email, password).isCanceled } returns false
+    every { mock.signInWithEmailAndPassword(email, password).result.user?.uid } answers { userId }
   }
 
   fun throwWhenSignInCalledWithCredentials(
@@ -57,18 +49,10 @@ class FakeFirebaseAuth {
     password: String,
     userId: String,
   ) {
-    every {
-      mock.createUserWithEmailAndPassword(email, password).isComplete
-    } returns true
-    every {
-      mock.createUserWithEmailAndPassword(email, password).exception
-    } returns null
-    every {
-      mock.createUserWithEmailAndPassword(email, password).isCanceled
-    } returns false
-    every {
-      mock.createUserWithEmailAndPassword(email, password).result.user?.uid
-    } answers { userId }
+    every { mock.createUserWithEmailAndPassword(email, password).isComplete } returns true
+    every { mock.createUserWithEmailAndPassword(email, password).exception } returns null
+    every { mock.createUserWithEmailAndPassword(email, password).isCanceled } returns false
+    every { mock.createUserWithEmailAndPassword(email, password).result.user?.uid } answers { userId }
   }
 
   fun throwWhenSignUpCalledWithCredentials(

--- a/auth/data/src/androidTest/java/app/taskify/auth/data/repository/ProdAuthRepositoryTest.kt
+++ b/auth/data/src/androidTest/java/app/taskify/auth/data/repository/ProdAuthRepositoryTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.data.repository
+
+import app.taskify.auth.data.fake.FakeFirebaseAuth
+import app.taskify.auth.domain.util.EmailAlreadyInUseException
+import app.taskify.auth.domain.util.InvalidCredentialsException
+import app.taskify.core.domain.exception.NetworkException
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseNetworkException
+import com.google.firebase.auth.FirebaseAuthException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProdAuthRepositoryTest {
+
+  private lateinit var fakeFirebaseAuth: FakeFirebaseAuth
+  private lateinit var repository: ProdAuthRepository
+
+  private val defaultEmail = "hello@johndoe.com"
+  private val defaultPassword = "12345678"
+
+  @Before
+  fun setup() {
+    fakeFirebaseAuth = FakeFirebaseAuth()
+    repository = ProdAuthRepository(fakeFirebaseAuth.mock)
+  }
+
+  @Test
+  fun networkDisconnectedWhileSigningIn() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeFirebaseAuth.throwWhenSignInCalledWithCredentials(
+      email = email,
+      password = password,
+      exception = FirebaseNetworkException("DISCONNECTED"),
+    )
+
+    val result = repository.signIn(email, password)
+
+    assertThat(result.isFailure).isTrue()
+    assertThat(result.exceptionOrNull()).isNotNull()
+    assertThat(result.exceptionOrNull()).isInstanceOf(NetworkException::class.java)
+  }
+
+  @Test
+  fun networkDisconnectedWhileSigningUp() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeFirebaseAuth.throwWhenSignUpCalledWithCredentials(
+      email = email,
+      password = password,
+      exception = FirebaseNetworkException("DISCONNECTED"),
+    )
+
+    val result = repository.signUp(email, password)
+
+    assertThat(result.isFailure).isTrue()
+    assertThat(result.exceptionOrNull()).isNotNull()
+    assertThat(result.exceptionOrNull()).isInstanceOf(NetworkException::class.java)
+  }
+
+  @Test
+  fun emailAlreadyInUse() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeFirebaseAuth.throwWhenSignUpCalledWithCredentials(
+      email = email,
+      password = password,
+      exception = FirebaseAuthException("ERROR_EMAIL_ALREADY_IN_USE", "email is already in use"),
+    )
+
+    val result = repository.signUp(email, password)
+
+    assertThat(result.isFailure).isTrue()
+    assertThat(result.exceptionOrNull()).isNotNull()
+    assertThat(result.exceptionOrNull()).isInstanceOf(EmailAlreadyInUseException::class.java)
+  }
+
+  @Test
+  fun invalidCredentials() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+
+    fakeFirebaseAuth.throwWhenSignInCalledWithCredentials(
+      email = email,
+      password = password,
+      exception = FirebaseAuthException("ERROR_INVALID_CREDENTIAL", "email or password went wrong"),
+    )
+
+    val result = repository.signIn(email, password)
+
+    assertThat(result.isFailure).isTrue()
+    assertThat(result.exceptionOrNull()).isNotNull()
+    assertThat(result.exceptionOrNull()).isInstanceOf(InvalidCredentialsException::class.java)
+  }
+
+  @Test
+  fun unexpectedExceptionOnSignIn() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val unexpectedException = RuntimeException()
+
+    fakeFirebaseAuth.throwWhenSignInCalledWithCredentials(
+      email = email,
+      password = password,
+      exception = unexpectedException,
+    )
+
+    val result = repository.signIn(email, password)
+
+    assertThat(result.isFailure).isTrue()
+    assertThat(result.exceptionOrNull()).isNotNull()
+    assertThat(result.exceptionOrNull()).isEqualTo(unexpectedException)
+  }
+
+  @Test
+  fun unexpectedExceptionOnSignUp() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val unexpectedException = RuntimeException()
+
+    fakeFirebaseAuth.throwWhenSignUpCalledWithCredentials(
+      email = email,
+      password = password,
+      exception = unexpectedException,
+    )
+
+    val result = repository.signUp(email, password)
+
+    assertThat(result.isFailure).isTrue()
+    assertThat(result.exceptionOrNull()).isNotNull()
+    assertThat(result.exceptionOrNull()).isEqualTo(unexpectedException)
+  }
+
+  @Test
+  fun signInIsSuccessful() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val userId = "user id"
+
+    fakeFirebaseAuth.mockSignInUserIdForCredentials(email, password, userId)
+
+    val result = repository.signIn(email, password)
+
+    assertThat(result.isSuccess).isTrue()
+    assertThat(result.getOrNull()).isNotNull()
+    assertThat(result.getOrNull()).isEqualTo(userId)
+  }
+
+  @Test
+  fun signUpIsSuccessful() = runTest {
+    val email = defaultEmail
+    val password = defaultPassword
+    val userId = "user id"
+
+    fakeFirebaseAuth.mockSignUpUserIdForCredentials(email, password, userId)
+
+    val result = repository.signUp(email, password)
+
+    assertThat(result.isSuccess).isTrue()
+    assertThat(result.getOrNull()).isNotNull()
+    assertThat(result.getOrNull()).isEqualTo(userId)
+  }
+}

--- a/auth/data/src/main/java/app/taskify/auth/data/repository/ProdAuthRepository.kt
+++ b/auth/data/src/main/java/app/taskify/auth/data/repository/ProdAuthRepository.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package app.taskify.auth.data.repository
+
+import app.taskify.auth.domain.repository.AuthRepository
+import app.taskify.auth.domain.util.EmailAlreadyInUseException
+import app.taskify.auth.domain.util.InvalidCredentialsException
+import app.taskify.core.domain.exception.NetworkException
+import app.taskify.core.domain.util.resultOf
+import com.google.firebase.FirebaseNetworkException
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseAuthException
+import javax.inject.Inject
+import kotlinx.coroutines.tasks.await
+
+class ProdAuthRepository @Inject constructor(
+  private val firebaseAuth: FirebaseAuth,
+) : AuthRepository {
+
+  override suspend fun signIn(email: String, password: String): Result<String> = runCatching {
+    val signInResult = firebaseAuth.signInWithEmailAndPassword(email, password).await()
+    val userId = signInResult?.user?.uid
+    checkNotNull(userId)
+  }
+
+  override suspend fun signUp(email: String, password: String): Result<String> = runCatching {
+    val signInResult = firebaseAuth.createUserWithEmailAndPassword(email, password).await()
+    val userId = signInResult?.user?.uid
+    checkNotNull(userId)
+  }
+
+  private inline fun <T> runCatching(result: () -> T): Result<T> = resultOf(result) { throwable ->
+    when (throwable) {
+      is FirebaseNetworkException -> NetworkException(cause = throwable)
+      is FirebaseAuthException -> firebaseAuthExceptionToDomainException(throwable)
+      else -> throwable
+    }
+  }
+
+  // Handle all of the possible auth and profile exceptions here.
+  private fun firebaseAuthExceptionToDomainException(exception: FirebaseAuthException): Throwable {
+    return when (exception.errorCode) {
+      "ERROR_EMAIL_ALREADY_IN_USE" -> EmailAlreadyInUseException(cause = exception)
+
+      "ERROR_USER_NOT_FOUND", "ERROR_INVALID_CREDENTIAL", "ERROR_INVALID_EMAIL", "ERROR_WRONG_PASSWORD" -> {
+        InvalidCredentialsException(cause = exception)
+      }
+
+      else -> exception
+    }
+  }
+}

--- a/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signin/SignInUseCase.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signin/SignInUseCase.kt
@@ -50,7 +50,7 @@ class SignInUseCase @Inject constructor(
     emit(Authenticated)
   }
 
-  // TODO: Handle all of the possible auth and profile exceptions here.
+  // Handle all of the possible auth and profile exceptions here.
   private fun Throwable.toFailureSignInResult(): SignInResult.Failure = when (this) {
     is NetworkException -> NoNetworkConnection
     is InvalidCredentialsException -> InvalidCredentials

--- a/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signup/SignUpUseCase.kt
+++ b/auth/domain/src/main/java/app/taskify/auth/domain/usecases/signup/SignUpUseCase.kt
@@ -50,7 +50,7 @@ class SignUpUseCase @Inject constructor(
     emit(Authenticated)
   }
 
-  // TODO: Handle all of the possible auth and profile exceptions here.
+  // Handle all of the possible auth and profile exceptions here.
   private fun Throwable.toFailureSignInResult(): SignUpResult.Failure = when (this) {
     is NetworkException -> NoNetworkConnection
     is EmailAlreadyInUseException -> EmailAlreadyInUse

--- a/core/domain/src/main/java/app/taskify/core/domain/util/Result.kt
+++ b/core/domain/src/main/java/app/taskify/core/domain/util/Result.kt
@@ -18,10 +18,10 @@ package app.taskify.core.domain.util
 import java.util.concurrent.CancellationException
 
 @Suppress("TooGenericExceptionCaught")
-inline fun <T> resultOf(block: () -> T): Result<T> = try {
+inline fun <T> resultOf(block: () -> T, onFailure: (Throwable) -> Throwable = { it }): Result<T> = try {
   Result.success(block())
 } catch (cancellationException: CancellationException) {
   throw cancellationException
 } catch (throwable: Throwable) {
-  Result.failure(throwable)
+  Result.failure(onFailure(throwable))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+firebase-auth = { group = "com.google.firebase", name = "firebase-auth-ktx", version = "22.0.0" }
 
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 mockk = { group = "io.mockk", name = "mockk-android", version = "1.13.2" }


### PR DESCRIPTION
- `ProdAuthRepository` class is created to provide a single source of truth.
- `FakeFirebaseAuth` class is created, to create an instance of `ProdAuthRepository` in test sources.
- `ProdAuthRepositoryTest` test class is created to test the `ProdAuthRepository` class behavior.